### PR TITLE
Add Firefox plugin skeleton

### DIFF
--- a/Firefox/README.md
+++ b/Firefox/README.md
@@ -1,0 +1,13 @@
+# Firefox Extraction Extension
+
+This directory contains a proof-of-concept Firefox WebExtension and a native helper used to extract relevant content from web pages using an LLM.
+
+It includes:
+
+- `manifest.json` – extension manifest using MV3
+- `background.js` – background service worker driving the extraction loop
+- `content.js` – runs in the page to snapshot the DOM and apply selectors
+- `viewer.html` and friends – displays the cleaned view
+- `native_helper/` – minimal Python helper registered via native messaging
+
+The implementation is intentionally lightweight but follows the architecture described in the project overview.

--- a/Firefox/background.js
+++ b/Firefox/background.js
@@ -1,0 +1,54 @@
+let port = null;
+let latestResult = null;
+
+function connectNative() {
+  if (!port) {
+    port = browser.runtime.connectNative('com.myext.llmbridge');
+    port.onDisconnect.addListener(() => { port = null; });
+  }
+  return port;
+}
+
+function sendNative(message) {
+  return new Promise((resolve) => {
+    const p = connectNative();
+    function handler(response) {
+      p.onMessage.removeListener(handler);
+      resolve(response);
+    }
+    p.onMessage.addListener(handler);
+    p.postMessage(message);
+  });
+}
+
+browser.action.onClicked.addListener(async (tab) => {
+  await browser.tabs.sendMessage(tab.id, { type: 'snapshotRequest' });
+});
+
+browser.runtime.onMessage.addListener(async (msg, sender) => {
+  if (msg.type === 'snapshot') {
+    const response = await sendNative(msg.data);
+    await browser.tabs.sendMessage(sender.tab.id, {
+      type: 'runSelectors',
+      selectors: response.selectors || [],
+      groups: response.groups || {}
+    });
+  } else if (msg.type === 'extractionSummary') {
+    const check = await sendNative({ summary: msg.summary });
+    if (check && check.selectors && check.selectors.length) {
+      await browser.tabs.sendMessage(sender.tab.id, {
+        type: 'runSelectors',
+        selectors: check.selectors,
+        groups: check.groups || {}
+      });
+    } else {
+      latestResult = Object.assign({}, msg.summary, { groups: check.groups || msg.groups || {} });
+      await browser.tabs.create({ url: browser.runtime.getURL('viewer.html') });
+    }
+  }
+});
+
+// expose result to viewer
+export function getLatest() {
+  return latestResult;
+}

--- a/Firefox/content.js
+++ b/Firefox/content.js
@@ -1,0 +1,42 @@
+function prune(text) {
+  return (text || '').trim().slice(0, 32);
+}
+
+function walk(node, list) {
+  const id = list.length;
+  const info = {
+    id,
+    tag: node.tagName.toLowerCase(),
+    classes: node.className || '',
+    textPrefix: prune(node.textContent)
+  };
+  list.push(info);
+  if (node.children && node.children.length) {
+    info.children = [];
+    for (const child of node.children) {
+      info.children.push(list.length);
+      walk(child, list);
+    }
+  } else {
+    info.children = [];
+  }
+}
+
+async function handleSelectors(selectors, groups) {
+  const result = {};
+  for (const sel of selectors) {
+    const nodes = Array.from(document.querySelectorAll(sel.css)).slice(0, sel.maxItems || 30);
+    result[sel.name] = nodes.map(n => n.href || n.value || prune(n.textContent));
+  }
+  await browser.runtime.sendMessage({ type: 'extractionSummary', summary: result, groups });
+}
+
+browser.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'snapshotRequest') {
+    const list = [];
+    walk(document.body, list);
+    browser.runtime.sendMessage({ type: 'snapshot', data: { url: location.href, tree: list } });
+  } else if (msg.type === 'runSelectors') {
+    handleSelectors(msg.selectors, msg.groups);
+  }
+});

--- a/Firefox/manifest.json
+++ b/Firefox/manifest.json
@@ -1,0 +1,33 @@
+{
+  "manifest_version": 3,
+  "name": "LLM Content Extractor",
+  "description": "Extracts important page contents using an LLM-backed helper",
+  "version": "0.1",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "nativeMessaging"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "Extract Content"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["viewer.html", "viewer.css", "viewer.js"],
+      "matches": ["<all_urls>"]
+    }
+  ]
+}

--- a/Firefox/native_helper/helper.py
+++ b/Firefox/native_helper/helper.py
@@ -1,0 +1,35 @@
+import sys
+import json
+
+
+def process(message):
+    if 'tree' in message:
+        return {
+            'selectors': [
+                {'name': 'Article', 'css': 'article', 'maxItems': 30},
+                {'name': 'Links', 'css': 'a', 'maxItems': 20}
+            ],
+            'groups': {'Page': ['Article', 'Links']}
+        }
+    elif 'summary' in message:
+        # naive check: accept as is
+        return {'groups': {'Page': ['Article', 'Links']}}
+    return {}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        resp = process(msg)
+        sys.stdout.write(json.dumps(resp) + '\n')
+        sys.stdout.flush()
+
+
+if __name__ == '__main__':
+    main()

--- a/Firefox/native_helper/llmbridge.json
+++ b/Firefox/native_helper/llmbridge.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.myext.llmbridge",
+  "description": "LLM bridge for content extraction",
+  "path": "helper.py",
+  "type": "stdio",
+  "allowed_extensions": ["llmcontentextractor@example.com"]
+}

--- a/Firefox/viewer.css
+++ b/Firefox/viewer.css
@@ -1,0 +1,13 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1em;
+}
+section {
+  margin-bottom: 1em;
+}
+.block {
+  border: 1px solid #ccc;
+  margin: 0.5em 0;
+  padding: 0.5em;
+}

--- a/Firefox/viewer.html
+++ b/Firefox/viewer.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="viewer.css">
+</head>
+<body>
+<div id="content">Loading…</div>
+<script src="viewer.js"></script>
+</body>
+</html>

--- a/Firefox/viewer.js
+++ b/Firefox/viewer.js
@@ -1,0 +1,32 @@
+(async () => {
+  const bg = await browser.runtime.getBackgroundPage();
+  const data = bg.getLatest();
+  const container = document.getElementById('content');
+  container.innerHTML = '';
+  if (!data) {
+    container.textContent = 'No data available';
+    return;
+  }
+  for (const [group, names] of Object.entries(data.groups || {})) {
+    const sec = document.createElement('section');
+    sec.dataset.group = group;
+    const h2 = document.createElement('h2');
+    h2.textContent = group;
+    sec.appendChild(h2);
+    for (const name of names) {
+      const div = document.createElement('div');
+      div.className = 'block';
+      const h3 = document.createElement('h3');
+      h3.textContent = name;
+      div.appendChild(h3);
+      const items = data[name] || [];
+      for (const item of items) {
+        const p = document.createElement('p');
+        p.textContent = item;
+        div.appendChild(p);
+      }
+      sec.appendChild(div);
+    }
+    container.appendChild(sec);
+  }
+})();


### PR DESCRIPTION
## Summary
- add Firefox extension skeleton with manifest v3, content and background scripts
- add viewer page for displaying extracted groups
- include native helper python script and host manifest

## Testing
- `python3 -m py_compile Firefox/native_helper/helper.py`